### PR TITLE
Require cl library which defines defstruct

### DIFF
--- a/shared-buffer.el
+++ b/shared-buffer.el
@@ -21,6 +21,7 @@
 ;; along with Shared buffer.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Code:
+(require 'cl)
 
 (defstruct sb-package
   "This struct defines the format for packages sent to and


### PR DESCRIPTION
Many emacs installations don't load cl by default, which results in
the error message 
    Symbol's function definition is void: defstruct
when one tries to load shared-buffer.el
This fixes it.
